### PR TITLE
Change pre-allocated slice to empty slice.

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -138,7 +138,7 @@ func Fatal(log string, fields ...zapcore.Field) {
 
 func logSpan(span opentracing.Span, log string, fields ...zapcore.Field) {
 	if span != nil {
-		opentracingFields := make([]opentracinglog.Field, len(fields)+1)
+		var opentracingFields []opentracinglog.Field
 		if log != "" {
 			opentracingFields = append(opentracingFields, opentracinglog.String("event", log))
 		}


### PR DESCRIPTION
Code was previously appending fields to a pre-allocated slice resulting in the slice being potentially twice as long as it needed to be.